### PR TITLE
feat: Add discount and currency fields to invoice extraction

### DIFF
--- a/main.py
+++ b/main.py
@@ -410,6 +410,8 @@ async def read_root():
             "reference",
             "invoice_lines",
             "detected_language",
+            "discount",
+            "currency",
         ],
         "invoice_line_fields": [
             "product",
@@ -471,6 +473,8 @@ async def get_available_fields():
             "reference": "Invoice number or reference",
             "invoice_lines": "Array of line items (each with product, quantity, unit_price, taxes, vat_amount)",
             "detected_language": "Detected language",
+            "discount": "Discount amount applied to the invoice",
+            "currency": "Currency used in the document (e.g., SAR, USD, EUR)",
             "total_amount": "Total invoice amount",
             "tax_amount": "Total tax amount",
             "subtotal": "Subtotal before taxes",

--- a/src/core/invoice_extractorgemini.py
+++ b/src/core/invoice_extractorgemini.py
@@ -43,7 +43,9 @@ Generated json
   "invoice_bill_date": "",
   "reference": "",
   "invoice_lines": [],
-  "detected_language": ""
+  "detected_language": "",
+  "discount": "",
+  "currency": ""
 }
 
 Line Item Schema
@@ -99,6 +101,10 @@ reference: The unique identifier for this specific document or transaction. Look
 
 detected_language: The primary language of the text in the document (e.g., "Arabic", "English", "Mixed").
 
+discount: The total discount amount applied to the invoice. Look for fields like "Discount", "Discount Amount", "Total Discount". Strip all currency symbols and thousand separators. If no discount is mentioned, use "0".
+
+currency: The currency used in the document (e.g., "SAR", "USD", "EUR"). Look for currency symbols or abbreviations throughout the document. If not found, use an empty string "".
+
 Line Item Details (invoice_lines)
 
 Guideline for Transaction Slips: For bank slips or payment confirmations, invoice_lines should only contain the fees or charges levied by the biller (the bank). Examples include "SADAD Fee", "Commission", "Service Charge", "VAT on Fee". The main transaction amount being transferred is not a line item.
@@ -123,7 +129,7 @@ Schema Adherence: You must include all keys from the schemas in your response.
 
 Handling Missing Data:
 
-If a value for any top-level key cannot be found in the document, you must use an empty string "".
+If a value for any top-level key cannot be found in the document, you must use an empty string "". However, for the discount field, if no discount is found, use "0".
 
 If there are no applicable service fees or charges to list, you must use an empty array [] for the invoice_lines key.
 

--- a/src/core/invoice_extractoropenai.py
+++ b/src/core/invoice_extractoropenai.py
@@ -51,7 +51,9 @@ Generated json
   "invoice_bill_date": "",
   "reference": "",
   "invoice_lines": [],
-  "detected_language": ""
+  "detected_language": "",
+  "discount": "",
+  "currency": ""
 }
 
 Line Item Schema
@@ -110,6 +112,10 @@ reference: The unique identifier for this document. Look for "Invoice No.", "Ref
 
 detected_language: The primary language of the text in the document (e.g., "Arabic", "English", "Mixed").
 
+discount: The total discount amount applied to the invoice. Look for fields like "Discount", "Discount Amount", "Total Discount". Strip all currency symbols and commas. If no discount is mentioned, use "0".
+
+currency: The currency used in the document (e.g., "SAR", "USD", "EUR"). Look for currency symbols or abbreviations throughout the document.
+
 Line Item Details (invoice_lines)
 
 Guideline: For bank slips or payment confirmations, invoice_lines should only contain fees or charges levied by the biller (e.g., "Service Fee", "VAT on Fee"). The main transaction amount is not a line item.
@@ -135,9 +141,9 @@ STRICT SCHEMA ADHERENCE: You must include all keys from the schemas in your resp
 
 THE GOLDEN RULE FOR MISSING VALUES:
 
-A) Non-Numeric Fields: For any field that is not a number (e.g., partner, street, email,street2), if the information cannot be found, you MUST use "None" as the value.
+A) Non-Numeric Fields: For any field that is not a number (e.g., partner, street, email, street2, currency), if the information cannot be found, you MUST use "None" as the value.
 
-B) Numeric Fields: For fields within invoice_lines that represent a monetary value (unit_price, gross_amount), if a value is not present or cannot be read, you MUST use the string "0".
+B) Numeric Fields: For fields within invoice_lines that represent a monetary value (unit_price, gross_amount) and the discount field, if a value is not present or cannot be read, you MUST use the string "0".
 
 QUANTITY DEFAULT: For the quantity field in invoice_lines, if it is not explicitly stated on the document, you MUST use the string "1".
 

--- a/src/core/invoice_postprocessor.py
+++ b/src/core/invoice_postprocessor.py
@@ -59,6 +59,8 @@ class InvoicePostProcessor:
                 reference=extracted_data.reference,
                 invoice_lines=processed_lines,
                 detected_language=extracted_data.detected_language,
+                discount=extracted_data.discount,
+                currency=extracted_data.currency,
                 filename=extracted_data.filename,
             )
 

--- a/src/models/extraction_models.py
+++ b/src/models/extraction_models.py
@@ -30,4 +30,6 @@ class InvoiceDataExtracted(BaseModel):
     reference: str
     invoice_lines: List[InvoiceLineExtracted]
     detected_language: str
+    discount: Optional[str] = "0"
+    currency: Optional[str] = ""
     filename: Optional[str] = None

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -37,6 +37,8 @@ class InvoiceData(BaseModel):
     reference: str
     invoice_lines: List[InvoiceLine]
     detected_language: str
+    discount: Optional[str] = "0"
+    currency: Optional[str] = ""
     filename: Optional[str] = None
 
 


### PR DESCRIPTION
feat: Add discount and currency fields to invoice extraction


- Add discount and currency fields to InvoiceDataExtracted and InvoiceData models
- Update OpenAI extractor prompt to include discount and currency extraction guidelines
- Update Gemini extractor schema and prompt for new fields
- Modify invoice postprocessor to handle discount and currency field mapping
- Update main.py documentation to include new available fields
- Set default values: discount="0" for missing values, currency="None" for missing values
- Ensure backward compatibility with existing extraction workflow